### PR TITLE
added extra parentheses around quantifications

### DIFF
--- a/lib_embedding/src/main/java/transformation/ModalTransformator.java
+++ b/lib_embedding/src/main/java/transformation/ModalTransformator.java
@@ -531,6 +531,13 @@ public class ModalTransformator {
                 }
                 thf_typed_variable.addChildAt(quant,0);
 
+                // add bracket left
+                Node bracketLeft2 = new Node("t_opening_bracket","(");
+                thf_typed_variable.addChildAt(bracketLeft2,0);
+
+                // add bracket right
+                Node bracketRight2 = new Node("t_closing_bracket",")");
+                n.addChild(bracketRight2);
             }else{
                 throw new TransformationException("Only typed variables are supported. " + thf_variable_list.toStringLeafs() + " does have untyped variables.");
             }


### PR DESCRIPTION
`$box @ ! [X: $i] : ( f @ X )`
was translated to
`mbox@mforall_vary__o__d_i_c_@(^ [ X : ($i) ] : ((f@X)))`
but should be translated to
`mbox@(mforall_vary__o__d_i_c_@(^ [ X : ($i) ] : ((f@X))))`
note the extra parentheses around mforall_vary_...

The first translation is not type correct. The update should add extra parentheses around every embedded quantification.